### PR TITLE
Fix settings apiRequest usage

### DIFF
--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -83,7 +83,7 @@ export default function Settings() {
         ...data,
         profileImage: profileImage
       };
-      return apiRequest("POST", "/api/settings/profile", payload);
+      return apiRequest("/api/settings/profile", "POST", payload);
     },
     onSuccess: () => {
       toast({
@@ -104,7 +104,7 @@ export default function Settings() {
 
   const updateBankingMutation = useMutation({
     mutationFn: async (data: any) => {
-      return apiRequest("POST", "/api/settings/banking", data);
+      return apiRequest("/api/settings/banking", "POST", data);
     },
     onSuccess: () => {
       toast({


### PR DESCRIPTION
## Summary
- ensure apiRequest is called with URL first and method second in settings

## Testing
- `npm run check` *(fails: product-edit.tsx ts errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840aae0aee4832184531fbb940f1806